### PR TITLE
Dealing with different endianess

### DIFF
--- a/pyntcloud/io/ply.py
+++ b/pyntcloud/io/ply.py
@@ -134,12 +134,12 @@ def read_ply(filename):
         with open(filename, 'rb') as ply:
             ply.seek(end_header)
             points_np = np.fromfile(ply, dtype=dtypes["vertex"], count=points_size)
-            if points_np.dtype.byteorder not in ('=', sys_byteorder):
+            if points_np.dtype.byteorder not in ('=', '|', sys_byteorder):
                 points_np = points_np.byteswap().newbyteorder()
             data["points"] = pd.DataFrame(points_np)
             if mesh_size is not None:
                 mesh_np = np.fromfile(ply, dtype=dtypes["face"], count=mesh_size)
-                if mesh_np.dtype.byteorder not in ('=', sys_byteorder):
+                if mesh_np.dtype.byteorder not in ('=', '|', sys_byteorder):
                     mesh_np = mesh_np.byteswap().newbyteorder()
                 data["mesh"] = pd.DataFrame(mesh_np)
                 data["mesh"].drop('n_points', axis=1, inplace=True)

--- a/pyntcloud/io/ply.py
+++ b/pyntcloud/io/ply.py
@@ -134,12 +134,12 @@ def read_ply(filename):
         with open(filename, 'rb') as ply:
             ply.seek(end_header)
             points_np = np.fromfile(ply, dtype=dtypes["vertex"], count=points_size)
-            if points_np.dtype.byteorder not in ('=', '|', sys_byteorder):
+            if ext != sys_byteorder:
                 points_np = points_np.byteswap().newbyteorder()
             data["points"] = pd.DataFrame(points_np)
             if mesh_size is not None:
                 mesh_np = np.fromfile(ply, dtype=dtypes["face"], count=mesh_size)
-                if mesh_np.dtype.byteorder not in ('=', '|', sys_byteorder):
+                if ext != sys_byteorder:
                     mesh_np = mesh_np.byteswap().newbyteorder()
                 data["mesh"] = pd.DataFrame(mesh_np)
                 data["mesh"].drop('n_points', axis=1, inplace=True)

--- a/pyntcloud/io/ply.py
+++ b/pyntcloud/io/ply.py
@@ -135,12 +135,12 @@ def read_ply(filename):
             ply.seek(end_header)
             points_np = np.fromfile(ply, dtype=dtypes["vertex"], count=points_size)
             if points_np.dtype.byteorder not in ('=', sys_byteorder):
-                points_np.byteswap(inplace=True).newbyteorder()
+                points_np = points_np.byteswap().newbyteorder()
             data["points"] = pd.DataFrame(points_np)
             if mesh_size is not None:
                 mesh_np = np.fromfile(ply, dtype=dtypes["face"], count=mesh_size)
                 if mesh_np.dtype.byteorder not in ('=', sys_byteorder):
-                    mesh_np.byteswap(inplace=True).newbyteorder()
+                    mesh_np = mesh_np.byteswap().newbyteorder()
                 data["mesh"] = pd.DataFrame(mesh_np)
                 data["mesh"].drop('n_points', axis=1, inplace=True)
 


### PR DESCRIPTION
It seems that pandas DataFrame doesn't accept not native endianness. In case of binary PLY files with opposite endianness that makes it fail. More info are available here https://pandas.pydata.org/pandas-docs/stable/gotchas.html#byte-ordering-issues.
I've modified the arrays to swap to a new byteorder in case the order isn't the native one.

Great work btw, thanks for this nice library! :)