### PR TITLE
Make importing Pyntcloud a bit easier

### DIFF
--- a/pyntcloud/__init__.py
+++ b/pyntcloud/__init__.py
@@ -1,5 +1,3 @@
-from .core_class import PyntCloud
-
 MAJOR = 0
 MINOR = 1
 MICRO = 0

--- a/pyntcloud/__init__.py
+++ b/pyntcloud/__init__.py
@@ -1,5 +1,1 @@
-MAJOR = 0
-MINOR = 1
-MICRO = 0
-
-__version__ = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
+from .core_class import PyntCloud

--- a/pyntcloud/core_class.py
+++ b/pyntcloud/core_class.py
@@ -2,13 +2,10 @@ import os
 import numpy as np
 import pandas as pd
 
-import matplotlib.pyplot as plt
-
 from .structures.base import StructuresDict
 from .filters import ALL_FILTERS
 from .io import FROM, TO
 from .neighbors import k_neighbors, r_neighbors
-from .plot import DESCRIPTION, plot_PyntCloud
 from .samplers import ALL_SAMPLERS
 from .scalar_fields import ALL_SF
 from .structures import ALL_STRUCTURES
@@ -673,13 +670,15 @@ class PyntCloud(object):
         html. You might need to run a local server or adjust the browser privacy
         policies in order to allow javascript to load local files.
         """
+        from .plot import DESCRIPTION, plot_PyntCloud
         try:
             colors = self.points[use_as_color].values
         except:
             colors = None
 
         if use_as_color != ["red", "green", "blue"] and colors is not None:
-            s_m = plt.cm.ScalarMappable(cmap=cmap)
+            from matplotlib.pyplot.cm import ScalarMappable
+            s_m = ScalarMappable(cmap=cmap)
             colors = s_m.to_rgba(colors)[:, :-1] * 255
 
         elif colors is None:

--- a/pyntcloud/core_class.py
+++ b/pyntcloud/core_class.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 
 from .structures.base import StructuresDict
+from .plot import DESCRIPTION
 from .filters import ALL_FILTERS
 from .io import FROM, TO
 from .neighbors import k_neighbors, r_neighbors
@@ -670,7 +671,7 @@ class PyntCloud(object):
         html. You might need to run a local server or adjust the browser privacy
         policies in order to allow javascript to load local files.
         """
-        from .plot import DESCRIPTION, plot_PyntCloud
+        from .plot import plot_PyntCloud
         try:
             colors = self.points[use_as_color].values
         except:

--- a/pyntcloud/plot/voxelgrid.py
+++ b/pyntcloud/plot/voxelgrid.py
@@ -3,9 +3,6 @@ import shutil
 
 import numpy as np
 
-from IPython.display import IFrame
-from matplotlib import pyplot as plt
-
 
 def plot_voxelgrid(voxelgrid,
                    mode="binary",
@@ -14,7 +11,8 @@ def plot_voxelgrid(voxelgrid,
                    output_name=None,
                    width=800,
                    height=500):
-
+    from IPython.display import IFrame
+    from matplotlib import pyplot as plt
     scaled_shape = voxelgrid.shape / min(voxelgrid.shape)
 
     vector = voxelgrid.get_feature_vector(mode=mode)

--- a/pyntcloud/structures/voxelgrid.py
+++ b/pyntcloud/structures/voxelgrid.py
@@ -1,5 +1,4 @@
 import numpy as np
-from matplotlib import pyplot as plt
 from scipy.spatial import cKDTree
 
 from .base import Structure
@@ -247,8 +246,8 @@ class VoxelGrid(Structure):
              output_name=None,
              width=800,
              height=500):
+        from matplotlib import pyplot as plt
         feature_vector = self.get_feature_vector(mode)
-
         if d == 2:
             fig, axes = plt.subplots(
                 int(np.ceil(self.x_y_z[2] / 4)), 4, figsize=(8, 8))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
-import pyntcloud
 from setuptools import setup, find_packages
 
-version = pyntcloud.__version__
+# Version
+MAJOR = 0
+MINOR = 1
+MICRO = 0
+
+version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 
 setup(
     name='pyntcloud',


### PR DESCRIPTION
That `.core_class import PyntCloud` seems to be causing troubles when installing with pip without the requirements (they should be already handled by setup.py). Is there any particular reason that line is there?