### PR TITLE
Re-add initial_point_size parameter to plot(). Fixes #198

### DIFF
--- a/pyntcloud/core_class.py
+++ b/pyntcloud/core_class.py
@@ -630,6 +630,7 @@ class PyntCloud(object):
         background="black",
         mesh=False,
         use_as_color=["red", "green", "blue"],
+        initial_point_size=0.0,
         cmap="hsv",
         polylines=None,
         linewidth=5,


### PR DESCRIPTION
I looked a bit further and I think this just got lost in a merge. I've re-added it as it was originally in f3447a852a77172ecbecdf46945613c8d592667d. Fixes #198