### PR TITLE
Update convex_hull.py positional arguments

### DIFF
--- a/pyntcloud/structures/convex_hull.py
+++ b/pyntcloud/structures/convex_hull.py
@@ -10,7 +10,7 @@ class ConvexHull(scipy_ConvexHull, Structure):
     def __init__(self, points,
                  incremental=False,
                  qhull_options=None):
-        Structure.__init__(self, points)
+        Structure.__init__(self, points=points)
         self._incremental = incremental
         self._qhull_options = qhull_options
 


### PR DESCRIPTION
Currently adding a new structure with convex_hull argument causes:

TypeError: __init__() takes 1 positional argument but 2 were given

This solves the error.