### PR TITLE
ModelNet bugfixes

### DIFF
--- a/pyntcloud/learn/datasets/modelnet.py
+++ b/pyntcloud/learn/datasets/modelnet.py
@@ -66,6 +66,7 @@ def get_and_setup_modelnet(N):
     cwd = os.getcwd()
     zip_file = f"{cwd}/modelnet{N}.zip"
     extract_folder = f"{cwd}/modelnet{N}"
+    BASE_folder = f"{cwd}/modelnet{N}/ModelNet{N}"
 
     if not os.path.exists(zip_file):
         print(f"Downloading ModelNet{N}")
@@ -76,6 +77,10 @@ def get_and_setup_modelnet(N):
         print("Unzipping ModelNet")
         with zipfile.ZipFile(zip_file) as zf:
             zf.extractall(extract_folder)
+
+    if not os.path.exists(BASE_folder):
+        os.makedirs(BASE_folder)
+        # recreate BASE if deleted
 
     print("Removing __MACOSX")
     # Thanks, Steve Jobs

--- a/pyntcloud/learn/load_3D.py
+++ b/pyntcloud/learn/load_3D.py
@@ -47,7 +47,7 @@ def load_3D(path,
 
     if point_cloud.mesh is not None:
         point_cloud = PyntCloud(point_cloud.get_sample(
-            "mesh_random_sampling", n=n_sampling))
+            "mesh_random", n=n_sampling))
 
     if voxelize:
         vgrid_id = point_cloud.add_structure("voxelgrid", x_y_z=target_size)


### PR DESCRIPTION
There are two changes I've made. In order of the commits-  

**incorrect 'name' parameter in call to PyntCloud.get_sample()**
The 'name' parameter provided in load_3D didn't match anything in the ALL_SAMPLERS dictionary. Fixed to match, and not error when called. 

Encountered this error when playing with ModelNet. The following would throw an error. 

`mnt = ModelNet10()`
`print(mnt[0])`
`#^ this __getitem__ call leads to the incorrect load_3D call`

**Error with multiple initializations of ModelNet10/40**
I encountered this error with the following line in a Jupyter Notebook. It works the first time the cell is run. Every run afterward throws an error because modelnet{N}/ModelNet{N} doesn't exist (it was deleted with the first run).

`mnt = ModelNet10()`

