### PR TITLE
fixed str to int bug

### DIFF
--- a/pyntcloud/core_class.py
+++ b/pyntcloud/core_class.py
@@ -564,9 +564,9 @@ class PyntCloud(object):
 
         points = self.points[use_columns].values
 
-        v1 = points[self.mesh["v1"].values]
-        v2 = points[self.mesh["v2"].values]
-        v3 = points[self.mesh["v3"].values]
+        v1 = points[self.mesh["v1"].astype(int).values]
+        v2 = points[self.mesh["v2"].astype(int).values]
+        v3 = points[self.mesh["v3"].astype(int).values]
 
         return v1, v2, v3
 

--- a/pyntcloud/io/obj.py
+++ b/pyntcloud/io/obj.py
@@ -72,7 +72,7 @@ def read_obj(filename):
         for i in range(sum(c.isdigit() for c in f[0].split(" "))):
             mesh_columns.append("v{}".format(i + 1))
 
-    mesh = pd.DataFrame([re.split(r'\D+', x) for x in f], dtype='i4', columns=mesh_columns)
+    mesh = pd.DataFrame([re.split(r'\D+', x) for x in f], dtype='float', columns=mesh_columns)
     mesh -= 1  # index starts with 1 in obj file
 
     data["mesh"] = mesh


### PR DESCRIPTION
For some obj files the import failed with following error:
`TypeError: unsupported operand type(s) for -: 'str' and 'int'`

This was due to this line here:  `mesh -= 1` where in some cases the pandas failed to convert to int, but instead converted it to string.
However, an float array can't be used as an array indexer, so the astype conversion is necessary. 
I think this is also related to #230
