### PR TITLE
Add PyVista backend

### DIFF
--- a/pyntcloud/core_class.py
+++ b/pyntcloud/core_class.py
@@ -7,7 +7,7 @@ from .structures.base import StructuresDict
 from .filters import ALL_FILTERS
 from .io import FROM, TO
 from .neighbors import k_neighbors, r_neighbors
-from .plot import DESCRIPTION
+from .plot import DESCRIPTION, AVAILABLE_BACKENDS
 from .plot.matplotlib_backend import plot_with_matplotlib
 from .plot.threejs_backend import plot_with_threejs
 from .plot.pythreejs_backend import plot_with_pythreejs
@@ -627,7 +627,7 @@ class PyntCloud(object):
 
     def plot(
             self,
-            backend="pythreejs",
+            backend=None,
             scene=None,
             width=800,
             height=500,
@@ -701,9 +701,16 @@ class PyntCloud(object):
         args = locals()
         backend = args.pop("backend")
 
+        # Choose fisrt avaialable backend
+        if backend is None and len(AVAILABLE_BACKENDS) > 0:
+            backend = AVAILABLE_BACKENDS[0]
+        elif backend is None:
+            backend = 'pythreejs'
+
+        # Plot with backend of choice
         if backend == "matplotlib":
             return plot_with_matplotlib(self, **args)
-        if backend == "pythreejs":
+        elif backend == "pythreejs":
             return plot_with_pythreejs(self, **args)
         elif backend == "threejs":
             return plot_with_threejs(self, **args)

--- a/pyntcloud/plot/__init__.py
+++ b/pyntcloud/plot/__init__.py
@@ -20,7 +20,7 @@ except ImportError:
     pass
 # Add PyVista
 try:
-    import pythreejs
+    import pyvista
     AVAILABLE_BACKENDS.append("pyvista")
 except ImportError:
     pass

--- a/pyntcloud/plot/__init__.py
+++ b/pyntcloud/plot/__init__.py
@@ -18,6 +18,12 @@ try:
     AVAILABLE_BACKENDS.append("pythreejs")
 except ImportError:
     pass
+# Add PyVista
+try:
+    import pythreejs
+    AVAILABLE_BACKENDS.append("pyvista")
+except ImportError:
+    pass
 # Add matplotlib
 try:
     import matplotlib

--- a/pyntcloud/plot/__init__.py
+++ b/pyntcloud/plot/__init__.py
@@ -9,3 +9,24 @@ PyntCloud
 Centroid: {}, {}, {}
 Other attributes:{}
 """
+
+AVAILABLE_BACKENDS = []
+# Add each backend in order of preference
+# Add pythreejs
+try:
+    import pythreejs
+    AVAILABLE_BACKENDS.append("pythreejs")
+except ImportError:
+    pass
+# Add matplotlib
+try:
+    import matplotlib
+    AVAILABLE_BACKENDS.append("matplotlib")
+except ImportError:
+    pass
+# Add threejs
+try:
+    from IPython.display import IFrame
+    AVAILABLE_BACKENDS.append("threejs")
+except ImportError:
+    pass

--- a/pyntcloud/plot/pyvista_backend.py
+++ b/pyntcloud/plot/pyvista_backend.py
@@ -1,0 +1,77 @@
+import numpy as np
+
+try:
+    import pyvista as pv
+except ImportError:
+    pv = None
+
+from .common import get_colors
+
+
+def plot_with_pyvista(cloud, **kwargs):
+    """Plot using PyVista. Additional kwargs for controoling PyVista scene are
+    listed here.
+
+
+    Parameters
+    ----------
+    off_screen : bool, optional
+        Renders off screen when False.  Useful for automated screenshots.
+
+    notebook : bool, optional
+        When True, the resulting plot is placed inline a jupyter notebook.
+        Assumes a jupyter console is active.  Automatically enables off_screen.
+
+    render_points_as_spheres : bool, optional
+        Render the points as spheres
+
+    eye_dome_lighting : bool, optional
+        Leverage PyVista's Eyd Dome Lighting (EDL) shading for improved
+        depth perception.
+
+    use_panel : bool, optional
+        If False, the interactive rendering from panel will not be used in
+        notebooks
+
+    cpos : list(tuple(floats))
+        The camera position to use
+
+    title : string, optional
+        Title of plotting window.
+
+    screenshot : string, optional
+        The path to the PNG file to save a screenshot
+
+    point_size : float, optional
+        Alias for ``initial_point_size``
+    """
+    if pv is None:
+        raise ImportError('PyVista must be installed to use it for plotting.')
+    # Get point size
+    point_size = kwargs["initial_point_size"]
+    if point_size is None:
+        point_size = kwargs.pop("point_size", 5.0)
+
+    # Get an RGB array using PyntCloud
+    colors = get_colors(cloud, kwargs["use_as_color"], kwargs["cmap"])
+
+    poly_data = cloud.to_pyvista(mesh=kwargs.pop("mesh", False))
+
+    plotter = pv.Plotter(window_size=[kwargs.pop("width"), kwargs.pop("height")],
+                         off_screen=kwargs.pop("off_screen", None),
+                         notebook=kwargs.pop("notebook", None))
+
+    # Add the poly data to the scene
+    plotter.add_mesh(poly_data, point_size=point_size, scalars=colors, rgb=True,
+                     render_points_as_spheres=kwargs.pop("render_points_as_spheres", False),
+                     )
+
+    if kwargs.pop("eye_dome_lighting", None):
+        plotter.enable_eye_dome_lighting()
+
+    # TODO: Leverage `kwargs["elev"]` and `kwargs["azim"]`
+
+    return plotter.show(use_panel=kwargs.pop("use_panel", None),
+                        title=kwargs.pop("title", None),
+                        screenshot=kwargs.pop("screenshot", False),
+                        cpos=kwargs.pop("cpos", None) )

--- a/tests/test_core_class.py
+++ b/tests/test_core_class.py
@@ -5,6 +5,13 @@ import pandas as pd
 from shutil import rmtree
 from pyntcloud import PyntCloud
 
+try:
+    import pyvista as pv
+    SKIP_PYVISTA = False
+except:
+    pv = None
+    SKIP_PYVISTA = True
+
 path = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -94,3 +101,14 @@ def test_split_on():
     assert len(output) == 8
 
     rmtree("tmp_out")
+
+@pytest.mark.skipif(SKIP_PYVISTA, reason="Requires PyVista")
+def test_pyvista_conversion():
+    cloud = PyntCloud.from_file(path + "/data/diamond.ply")
+    poly = cloud.to_pyvista(mesh=True)
+    pc = PyntCloud.from_pyvista(poly)
+    assert np.allclose(cloud.points[['x', 'y', 'z']].values, poly.points)
+    assert np.allclose(cloud.mesh.values, pc.mesh.values)
+    poly = pyvista.read("/data/diamond.ply")
+    pc = PyntCloud.from_pyvista(poly)
+    assert np.allclose(pc.points[['x', 'y', 'z']].values, poly.points)


### PR DESCRIPTION
Resolve #247 

These changes add support for using PyVista as a plotting backend.

```py
from pyntcloud import PyntCloud
anky = PyntCloud.from_file("data/ankylosaurus_mesh.ply")

# Use PyVista's notebook rendering:
anky.plot(backend='pyvista', use_panel=True, point_size=10, mesh=True)
```

![ezgif com-video-to-gif-4](https://user-images.githubusercontent.com/22067021/59621844-5a692580-90ed-11e9-92ce-e0027bc3f132.gif)


Or use more sophisticated rendering techniques with Eye Dome Lighting (EDL):
```py
anky.plot(backend='pyvista', notebook=False,
          eye_dome_lighting=True, point_size=10,)
```
<img width="1116" alt="Screen Shot 2019-06-17 at 10 47 24 AM" src="https://user-images.githubusercontent.com/22067021/59621825-4e7d6380-90ed-11e9-9984-fac11cd13d95.png">

You can also now leverage PyVista filters and bring the results right back to PyntCloud via `PyntCloud.from_pyvista`

```py
poly = anky.to_pyvista(mesh=True)
smooth = poly.smooth(1000)
pc_spooth = PyntCloud.from_pyvista(smooth)
pc_spooth.plot(backend='pyvista', mesh=True)
```

<img width="927" alt="Screen Shot 2019-06-17 at 10 56 16 AM" src="https://user-images.githubusercontent.com/22067021/59622346-8afd8f00-90ee-11e9-9f70-ece94f4167c2.png">



<img width="923" alt="Screen Shot 2019-06-17 at 10 53 32 AM" src="https://user-images.githubusercontent.com/22067021/59622364-951f8d80-90ee-11e9-9072-2b1984c7775c.png">


# Future Work

Down the road, we need to add PyVista converters for the voxel grids (and other mesh types)

# For the Reviewer

I'm not sure if I add scalar arrays to the `PyntCloud` object correctly in `from_pyvista`.

