### PR TITLE
add farthest point sampling for points sampler, and modify the uniform sampler for the meshes

### DIFF
--- a/pyntcloud/io/obj.py
+++ b/pyntcloud/io/obj.py
@@ -72,7 +72,7 @@ def read_obj(filename):
         for i in range(sum(c.isdigit() for c in f[0].split(" "))):
             mesh_columns.append("v{}".format(i + 1))
 
-    mesh = pd.DataFrame([re.split(r'\D+', x) for x in f], dtype='i4', columns=mesh_columns)
+    mesh = pd.DataFrame([re.split(r'\D+', x) for x in f], dtype='i4', columns=mesh_columns).astype('i4')
     mesh -= 1  # index starts with 1 in obj file
 
     data["mesh"] = mesh

--- a/pyntcloud/samplers/__init__.py
+++ b/pyntcloud/samplers/__init__.py
@@ -3,7 +3,7 @@
 HAKUNA MATATA
 """
 
-from .points import RandomPointsSampler
+from .points import RandomPointsSampler, FarthestPointsSampler
 from .mesh import RandomMeshSampler
 from .voxelgrid import (
     VoxelgridCentersSampler,
@@ -17,6 +17,7 @@ ALL_SAMPLERS = {
     'mesh_random': RandomMeshSampler,
     # Points
     'points_random': RandomPointsSampler,
+    'points_farthest': FarthestPointsSampler,
     # Voxelgrid
     'voxelgrid_centers': VoxelgridCentersSampler,
     'voxelgrid_centroids': VoxelgridCentroidsSampler,

--- a/pyntcloud/samplers/mesh.py
+++ b/pyntcloud/samplers/mesh.py
@@ -72,7 +72,7 @@ class RandomMeshSampler(MeshSampler):
 
         # (n, 1) the 1 is for broadcasting
         u = np.random.uniform(low=0., high=1., size=(self.n, 1))
-        v = np.random.uniform(low=0., high=u, size=(self.n, 1))
+        v = np.random.uniform(low=0., high=1-u, size=(self.n, 1))
 
         result = pd.DataFrame()
 

--- a/pyntcloud/samplers/mesh.py
+++ b/pyntcloud/samplers/mesh.py
@@ -71,12 +71,8 @@ class RandomMeshSampler(MeshSampler):
         v3_xyz = self.v3_xyz[random_idx]
 
         # (n, 1) the 1 is for broadcasting
-        u = np.random.rand(self.n, 1)
-        v = np.random.rand(self.n, 1)
-        is_a_problem = u + v > 1
-
-        u[is_a_problem] = 1 - u[is_a_problem]
-        v[is_a_problem] = 1 - v[is_a_problem]
+        u = np.random.uniform(low=0., high=1., size=(self.n, 1))
+        v = np.random.uniform(low=0., high=u, size=(self.n, 1))
 
         result = pd.DataFrame()
 

--- a/pyntcloud/samplers/points.py
+++ b/pyntcloud/samplers/points.py
@@ -30,39 +30,53 @@ class RandomPointsSampler(PointsSampler):
 
 
 class FarthestPointsSampler(PointsSampler):
+
     """
     Parameters
     ----------
     n: int
         Number of unique points that will be chosen.
+    d_metric: 3*3 numpy array
+        a positive semi-definite matrix which defines a distance metric
     """
 
-    def __init__(self, *, pyntcloud, n, d_metric=np.diag([1., 1., 1.])):
+    def __init__(self, *, pyntcloud, n, d_metric=np.eye(3)):
         """d_metric -> Euclidean distance space by default, can be modified to other Mahalanobis distance as well"""
         super().__init__(pyntcloud=pyntcloud)
         self.n = n
         if not np.all(np.linalg.eigvals(d_metric) >= 0):
-            raise ValueError("the Mahalanobis matrix must be positive semidefinite")
+            raise ValueError("the distance metric must be positive semi-definite")
         self.d_metric = d_metric
 
     def cal_distance(self, point, solution_set):
-        sum = 0
+        """
+        :param point: points which is not sampled yet, N*10 or N*3 numpy array
+        :param solution_set: the points which has been selected, M*3 or M*10 array
+        :return: a (N, ) array, where each element is equal to the sum of distance
+        of all points in 'solution_set' w.r.t the unselected point in the 'point'
+        """
+        distance_sum = np.zeros(len(point))
+
         for pt in solution_set:
-            sum += np.dot(point[:3]-pt[:3], self.d_metric)
-        return sum
+            distance_sum += np.diag(np.dot((point[:, :3]-pt[:3]), self.d_metric@(point[:, :3]-pt[:3]).T))
+        return distance_sum
 
     def compute(self):
         "incremental farthest search"
         if self.n > len(self.points):
-            raise ValueError("n can't be higher than the number of points in the PyntCloud.")
+            raise ValueError("sampled points can't be more than the original input")
         remaining_points = self.points.values
-        solution_set = list()
-        solution_set.append(remaining_points.pop(
-            random.randint(0, len(remaining_points) - 1)))
+
+        # the sampled points set as the return
+        select_idx = np.random.randint(low=0, high=len(self.points))
+        # to remain the shape as (1, n) instead of (n, )
+        solution_set = remaining_points[select_idx: select_idx+1]
+        remaining_points = np.delete(remaining_points, select_idx)
+
         for _ in range(self.n - 1):
-            distances = [self.cal_distance(p, solution_set[0]) for p in remaining_points]
-            for i, p in enumerate(remaining_points):
-                for j, s in enumerate(solution_set):
-                    distances[i] = min(distances[i], self.cal_distance(p, s))
-            solution_set.append(remaining_points.pop(distances.index(max(distances))))
-        return pd.DataFrame(solution_set)
+            distance_sum = self.cal_distance(remaining_points, solution_set)
+            select_idx = np.argmax(distance_sum)
+            solution_set = np.concatenate([solution_set, remaining_points[select_idx:select_idx+1]], axis=0)
+            remaining_points = np.delete(remaining_points, select_idx)
+
+        return pd.DataFrame(solution_set, columns=self.points.columns)

--- a/pyntcloud/samplers/points.py
+++ b/pyntcloud/samplers/points.py
@@ -71,12 +71,12 @@ class FarthestPointsSampler(PointsSampler):
         select_idx = np.random.randint(low=0, high=len(self.points))
         # to remain the shape as (1, n) instead of (n, )
         solution_set = remaining_points[select_idx: select_idx+1]
-        remaining_points = np.delete(remaining_points, select_idx)
+        remaining_points = np.delete(remaining_points, select_idx, 0)
 
         for _ in range(self.n - 1):
             distance_sum = self.cal_distance(remaining_points, solution_set)
             select_idx = np.argmax(distance_sum)
             solution_set = np.concatenate([solution_set, remaining_points[select_idx:select_idx+1]], axis=0)
-            remaining_points = np.delete(remaining_points, select_idx)
+            remaining_points = np.delete(remaining_points, select_idx, 0)
 
         return pd.DataFrame(solution_set, columns=self.points.columns)

--- a/pyntcloud/samplers/points.py
+++ b/pyntcloud/samplers/points.py
@@ -1,4 +1,7 @@
 from .base import Sampler
+import random
+import numpy as np
+import pandas as pd
 
 
 class PointsSampler(Sampler):
@@ -24,3 +27,42 @@ class RandomPointsSampler(PointsSampler):
         if self.n > len(self.points):
             raise ValueError("n can't be higher than the number of points in the PyntCloud.")
         return self.points.sample(self.n).reset_index(drop=True)
+
+
+class FarthestPointsSampler(PointsSampler):
+    """
+    Parameters
+    ----------
+    n: int
+        Number of unique points that will be chosen.
+    """
+
+    def __init__(self, *, pyntcloud, n, d_metric=np.diag([1., 1., 1.])):
+        """d_metric -> Euclidean distance space by default, can be modified to other Mahalanobis distance as well"""
+        super().__init__(pyntcloud=pyntcloud)
+        self.n = n
+        if not np.all(np.linalg.eigvals(d_metric) >= 0):
+            raise ValueError("the Mahalanobis matrix must be positive semidefinite")
+        self.d_metric = d_metric
+
+    def cal_distance(self, point, solution_set):
+        sum = 0
+        for pt in solution_set:
+            sum += np.dot(point[:3]-pt[:3], self.d_metric)
+        return sum
+
+    def compute(self):
+        "incremental farthest search"
+        if self.n > len(self.points):
+            raise ValueError("n can't be higher than the number of points in the PyntCloud.")
+        remaining_points = self.points.values
+        solution_set = list()
+        solution_set.append(remaining_points.pop(
+            random.randint(0, len(remaining_points) - 1)))
+        for _ in range(self.n - 1):
+            distances = [self.cal_distance(p, solution_set[0]) for p in remaining_points]
+            for i, p in enumerate(remaining_points):
+                for j, s in enumerate(solution_set):
+                    distances[i] = min(distances[i], self.cal_distance(p, s))
+            solution_set.append(remaining_points.pop(distances.index(max(distances))))
+        return pd.DataFrame(solution_set)

--- a/tests/integration/samplers/test_points_samplers.py
+++ b/tests/integration/samplers/test_points_samplers.py
@@ -50,6 +50,11 @@ def test_RandomPointsSampler_sampled_points_are_from_original(simple_pyntcloud):
         assert point_in_array_2D(sample, simple_pyntcloud.xyz)
 
 
+@pytest.mark.parametrize("n", [
+    1,
+    5,
+    6
+])
 @pytest.mark.usefixtures("simple_pyntcloud")
 def test_FarthestPointsSampler_n_argument(simple_pyntcloud, n):
     sample = simple_pyntcloud.get_sample(

--- a/tests/integration/samplers/test_points_samplers.py
+++ b/tests/integration/samplers/test_points_samplers.py
@@ -19,6 +19,7 @@ def test_mesh_random_sampling_return_type(simple_pyntcloud):
         as_PyntCloud=True)
     assert type(sample) == PyntCloud
 
+
 @pytest.mark.parametrize("n", [
     1,
     5,
@@ -48,3 +49,27 @@ def test_RandomPointsSampler_sampled_points_are_from_original(simple_pyntcloud):
             n=1)
         assert point_in_array_2D(sample, simple_pyntcloud.xyz)
 
+
+@pytest.mark.usefixtures("simple_pyntcloud")
+def test_FarthestPointsSampler_n_argument(simple_pyntcloud, n):
+    sample = simple_pyntcloud.get_sample(
+        "points_farthest",
+        n=n)
+    assert len(sample) == n
+
+
+@pytest.mark.usefixtures("simple_pyntcloud")
+def test_FarthestPointsSampler_raises_ValueError_on_invalid_n(simple_pyntcloud):
+    with pytest.raises(ValueError):
+        simple_pyntcloud.get_sample(
+            "points_farthest",
+            n=10)
+
+
+@pytest.mark.usefixtures("simple_pyntcloud")
+def test_FarthestPointsSampler_sampled_points_are_from_original(simple_pyntcloud):
+    for i in range(10):
+        sample = simple_pyntcloud.get_sample(
+            "points_farthest",
+            n=1)
+        assert point_in_array_2D(sample, simple_pyntcloud.xyz)


### PR DESCRIPTION
Hi, Castro

I have added farthest point sampling into the points sampler, which is an algorithm applied to the cutting-edge research, see [here](https://github.com/charlesq34/pointnet) for the relevant paper, and [here](https://flothesof.github.io/farthest-neighbors.html) for the description of the algorithm.

And I think it is probably better to sample `u, v` uniformly from `[0, 1]` and `[0, u]` respectively in the mesh sampler. Because to ensure the sampled points are within that face, it requires not only `u + v  <= 1` but also `u >= 0` and `v >= 0`, but for the original procedure, which is sampled from Gaussian then truncation, it did not resolve the issues with negative sampling results. Plus it is more concise now.

I am very interested to make more commitments since it intersects with my research projects during PhD, I think next step is to develop the Poisson Disk Sampling as discussed here: #239, and is it okay for me to develop a new part for the normals/curvatures calculations(directly from the points) and with reconstruction on the doc as well.

Thanks.