### PR TITLE
use raw string literal to address DeprecationWarning

### DIFF
--- a/pyntcloud/io/pcd.py
+++ b/pyntcloud/io/pcd.py
@@ -23,7 +23,7 @@ def parse_header(lines):
     for ln in lines:
         if ln.startswith('#') or len(ln) < 2:
             continue
-        match = re.match('(\w+)\s+([\w\s\.]+)', ln)
+        match = re.match(r'(\w+)\s+([\w\s\.]+)', ln)
         if not match:
             warnings.warn("warning: can't understand line: %s" % ln)
             continue


### PR DESCRIPTION
addresses `DeprecationWarning: invalid escape sequence \w` (in eg. Python 3.8)