### PR TITLE
fix python 10 ci

### DIFF
--- a/.github/workflows/pyncloud_ci.yml
+++ b/.github/workflows/pyncloud_ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
Currently github actions read `3.10` as `3.1`. It has to be in string.