### PR TITLE
PyVista: point_arrays -> point_data

### DIFF
--- a/pyntcloud/io/pyvista.py
+++ b/pyntcloud/io/pyvista.py
@@ -24,7 +24,7 @@ def from_pyvista(poly_data, **kwargs):
 
     points = pd.DataFrame(data=poly_data.points, columns=["x", "y", "z"])
 
-    scalars = poly_data.point_arrays
+    scalars = poly_data.point_data
     for name, array in scalars.items():
         if array.ndim == 1:
             points[name] = array
@@ -72,11 +72,11 @@ def to_pyvista(cloud, mesh=False, use_as_color=("red", "green", "blue"), **kwarg
     # add scalar arrays
     if all(c in cloud.points.columns for c in use_as_color):
         colors = cloud.points[list(use_as_color)].values
-        poly.point_arrays["RGB"] = colors
+        poly.point_data["RGB"] = colors
         avoid += list(use_as_color)
     # Add other arrays
     for name in cloud.points.columns:
         if name not in avoid:
-            poly.point_arrays[name] = cloud.points[name]
+            poly.point_data[name] = cloud.points[name]
 
     return poly

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ ipython
 matplotlib
 numba
 pytest
-pyvista
+pyvista>=0.32.0
 open3d

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     extras_require={
         'LAS':  ["pylas", "lazrs"],
-        'PLOT': ["ipython", "matplotlib", "pyvista"],
+        'PLOT': ["ipython", "matplotlib", "pyvista>=0.32.0"],
         'NUMBA': ["numba"]
     },
     classifiers=[

--- a/tests/integration/io/test_from_instance.py
+++ b/tests/integration/io/test_from_instance.py
@@ -23,9 +23,9 @@ def test_pyvista_conversion(data_path):
     cloud = PyntCloud.from_instance("pyvista", original_point_cloud)
     assert np.allclose(cloud.xyz, original_point_cloud.points)
     assert {'red', 'green', 'blue'}.issubset(cloud.points.columns)
-    assert np.allclose(cloud.points[['red', 'green', 'blue']].values, original_point_cloud.point_arrays["RGB"])
+    assert np.allclose(cloud.points[['red', 'green', 'blue']].values, original_point_cloud.point_data["RGB"])
     assert {'nx', 'ny', 'nz'}.issubset(cloud.points.columns)
-    assert np.allclose(cloud.points[['nx', 'ny', 'nz']].values,  original_point_cloud.point_arrays["Normals"])
+    assert np.allclose(cloud.points[['nx', 'ny', 'nz']].values,  original_point_cloud.point_data["Normals"])
     assert cloud.mesh is not None
 
 
@@ -39,7 +39,7 @@ def test_pyvista_normals_are_handled():
 @pytest.mark.skipif(SKIP_PYVISTA, reason="Requires PyVista")
 def test_pyvista_multicomponent_scalars_are_splitted():
     poly = pv.Sphere()
-    poly.point_arrays["foo"] = np.zeros_like(poly.points)
+    poly.point_data["foo"] = np.zeros_like(poly.points)
     pc = PyntCloud.from_instance("pyvista", poly)
     assert all(x in pc.points.columns for x in ["foo_0", "foo_1", "foo_2"])
 
@@ -50,7 +50,7 @@ def test_pyvista_rgb_is_handled():
     if poin_arrays contain a field with `name in "RGB"`
     """
     poly = pv.Sphere()
-    poly.point_arrays["RG"] = np.zeros_like(poly.points)[:, :2]
+    poly.point_data["RG"] = np.zeros_like(poly.points)[:, :2]
     pc = PyntCloud.from_instance("pyvista", poly)
     assert all(x in pc.points.columns for x in ["RG_0", "RG_1"])
 


### PR DESCRIPTION
Fixes a deprecation in PyVista's dataset attributes: `point_arrays` was renamed to `point_data` in v0.32.0 per https://github.com/pyvista/pyvista/pull/1593 and https://github.com/pyvista/pyvista/releases/tag/0.32.0