### PR TITLE
FIX: slow `read_off` method

### DIFF
--- a/pyntcloud/io/obj.py
+++ b/pyntcloud/io/obj.py
@@ -72,7 +72,9 @@ def read_obj(filename):
         for i in range(sum(c.isdigit() for c in f[0].split(" "))):
             mesh_columns.append("v{}".format(i + 1))
 
-    mesh = pd.DataFrame([re.split(r'\D+', x) for x in f], dtype='i4', columns=mesh_columns).astype('i4')
+    # trying to coerce type to integer throws error, casted afetr passes tests
+    # mesh = pd.DataFrame([re.split(r'\D+', x) for x in f], dtype='i4', columns=mesh_columns).astype('i4')
+    mesh = pd.DataFrame([re.split(r'\D+', x) for x in f], columns=mesh_columns).astype('i4')
     mesh -= 1  # index starts with 1 in obj file
 
     data["mesh"] = mesh

--- a/pyntcloud/io/obj.py
+++ b/pyntcloud/io/obj.py
@@ -73,7 +73,6 @@ def read_obj(filename):
             mesh_columns.append("v{}".format(i + 1))
 
     # trying to coerce type to integer throws error, casted afetr passes tests
-    # mesh = pd.DataFrame([re.split(r'\D+', x) for x in f], dtype='i4', columns=mesh_columns).astype('i4')
     mesh = pd.DataFrame([re.split(r'\D+', x) for x in f], columns=mesh_columns).astype('i4')
     mesh -= 1  # index starts with 1 in obj file
 

--- a/pyntcloud/io/off.py
+++ b/pyntcloud/io/off.py
@@ -41,13 +41,6 @@ def read_off(filename):
                                 index_col=False,
                                 comment="#"
                             )
-        
-        # for n in ["x", "y", "z"]:
-        #     data["points"][n] = data["points"][n].astype(np.float32)
-
-        # if color:
-        #     for n in ["red", "green", "blue"]:
-        #         data["points"][n] = data["points"][n].astype(np.uint8)
 
         data["mesh"] = pd.read_csv(
                             filename,

--- a/pyntcloud/io/off.py
+++ b/pyntcloud/io/off.py
@@ -8,7 +8,7 @@ def read_off(filename):
 
         first_line = off.readline()
         if "OFF" not in first_line:
-            raise ValueError('The file does not start whith the word OFF')
+            raise ValueError('The file does not start with the word OFF')
         color = True if "C" in first_line else False
 
         count = 1
@@ -24,20 +24,40 @@ def read_off(filename):
 
         data = {}
         point_names = ["x", "y", "z"]
+        point_types = {'x': np.float32, 'y': np.float32, 'z': np.float32}
+
         if color:
             point_names.extend(["red", "green", "blue"])
+            point_types = dict(point_types, **{'red': np.uint8, 'green': np.uint8, 'blue': np.uint8})
 
-        data["points"] = pd.read_csv(filename, sep=" ", header=None, engine="python",
-                                     skiprows=count, skipfooter=n_faces,
-                                     names=point_names, index_col=False)
-        for n in ["x", "y", "z"]:
-            data["points"][n] = data["points"][n].astype(np.float32)
+        data["points"] =    pd.read_csv(
+                                off,
+                                sep=" ",
+                                header=None,
+                                engine="c",
+                                n_rows=n_points,
+                                names=point_names,
+                                dtype=point_types,
+                                index_col=False,
+                                comment="#"
+                            )
+        
+        # for n in ["x", "y", "z"]:
+        #     data["points"][n] = data["points"][n].astype(np.float32)
 
-        if color:
-            for n in ["red", "green", "blue"]:
-                data["points"][n] = data["points"][n].astype(np.uint8)
+        # if color:
+        #     for n in ["red", "green", "blue"]:
+        #         data["points"][n] = data["points"][n].astype(np.uint8)
 
-        data["mesh"] = pd.read_csv(filename, sep=" ", header=None, engine="python",
-                                   skiprows=(count + n_points), usecols=[1, 2, 3],
-                                   names=["v1", "v2", "v3"])
+        data["mesh"] = pd.read_csv(
+                            filename,
+                            sep=" ",
+                            header=None,
+                            engine="c",
+                            skiprows=(count + n_points),
+                            n_rows=n_faces,
+                            usecols=[1, 2, 3],
+                            names=["v1", "v2", "v3"],
+                            comment="#"
+                        )
         return data

--- a/pyntcloud/io/off.py
+++ b/pyntcloud/io/off.py
@@ -11,6 +11,9 @@ def read_off(filename):
             raise ValueError('The file does not start with the word OFF')
         color = True if "C" in first_line else False
 
+        n_points = 0
+        n_faces = 0
+
         count = 1
         for line in off:
             count += 1
@@ -22,6 +25,9 @@ def read_off(filename):
                 n_faces = int(line[1])
                 break
 
+        # if (n_points == 0):
+            # raise ValueError('The file has no points')
+
         data = {}
         point_names = ["x", "y", "z"]
         point_types = {'x': np.float32, 'y': np.float32, 'z': np.float32}
@@ -30,27 +36,27 @@ def read_off(filename):
             point_names.extend(["red", "green", "blue"])
             point_types = dict(point_types, **{'red': np.uint8, 'green': np.uint8, 'blue': np.uint8})
 
-        data["points"] =    pd.read_csv(
-                                off,
-                                sep=" ",
-                                header=None,
-                                engine="c",
-                                n_rows=n_points,
-                                names=point_names,
-                                dtype=point_types,
-                                index_col=False,
-                                comment="#"
-                            )
+        data["points"] = pd.read_csv(
+            off,
+            sep=" ",
+            header=None,
+            engine="c",
+            nrows=n_points,
+            names=point_names,
+            dtype=point_types,
+            index_col=False,
+            comment="#"
+        )
 
         data["mesh"] = pd.read_csv(
-                            filename,
-                            sep=" ",
-                            header=None,
-                            engine="c",
-                            skiprows=(count + n_points),
-                            n_rows=n_faces,
-                            usecols=[1, 2, 3],
-                            names=["v1", "v2", "v3"],
-                            comment="#"
-                        )
+            filename,
+            sep=" ",
+            header=None,
+            engine="c",
+            skiprows=(count + n_points),
+            nrows=n_faces,
+            usecols=[1, 2, 3],
+            names=["v1", "v2", "v3"],
+            comment="#"
+        )
         return data

--- a/pyntcloud/io/off.py
+++ b/pyntcloud/io/off.py
@@ -25,8 +25,8 @@ def read_off(filename):
                 n_faces = int(line[1])
                 break
 
-        # if (n_points == 0):
-            # raise ValueError('The file has no points')
+        if (n_points == 0):
+            raise ValueError('The file has no points')
 
         data = {}
         point_names = ["x", "y", "z"]

--- a/pyntcloud/utils/numba.py
+++ b/pyntcloud/utils/numba.py
@@ -1,21 +1,21 @@
-from numba import jit
+from numba import njit
 
 
-@jit
+@njit
 def groupby_count(xyz, indices, out):
     for i in range(xyz.shape[0]):
         out[indices[i]] += 1
     return out
 
 
-@jit
+@njit
 def groupby_sum(xyz, indices, N, out):
     for i in range(xyz.shape[0]):
         out[indices[i]] += xyz[i][N]
     return out
 
 
-@jit
+@njit
 def groupby_max(xyz, indices, N, out):
     for i in range(xyz.shape[0]):
         if xyz[i][N] > out[indices[i]]:

--- a/tests/integration/io/test_to_file.py
+++ b/tests/integration/io/test_to_file.py
@@ -2,7 +2,7 @@ import pytest
 
 from pyntcloud import PyntCloud
 
-from .test_from_file import assert_points_xyz, assert_points_color, assert_mesh
+from test_from_file import assert_points_xyz, assert_points_color, assert_mesh
 
 
 @pytest.mark.parametrize("extension,color,mesh,comments", [

--- a/tests/integration/io/test_to_file.py
+++ b/tests/integration/io/test_to_file.py
@@ -2,7 +2,7 @@ import pytest
 
 from pyntcloud import PyntCloud
 
-from test_from_file import assert_points_xyz, assert_points_color, assert_mesh
+from .test_from_file import assert_points_xyz, assert_points_color, assert_mesh
 
 
 @pytest.mark.parametrize("extension,color,mesh,comments", [


### PR DESCRIPTION
Had to use this method for a project and it was incredibly slow.

Fixed changing the engine and tweaking the parameters so that no new import is required.

Also fixes:
- comments in file
- ignores edges that were previously read as faces
- direct type casting instead of casting after creating the `DataFrame`
- coercing error on obj.py
- changed jit decorator to njit
- little spelling mistake :)

I tried to modify the least I could.

Problems not solved:
- OFF files actually can have heterogeneous shapes... :(